### PR TITLE
Add PrecompiledAssets::Manifest#inspect

### DIFF
--- a/lib/precompiled_assets/manifest.rb
+++ b/lib/precompiled_assets/manifest.rb
@@ -29,6 +29,11 @@ module PrecompiledAssets
       mtime && mtime != fetch_mtime
     end
 
+    def inspect
+      truncated_parsed_manifest = "#{@parsed_manifest.to_s[0..7]}..."
+      "<#{self.class.name}:#{object_id} @pathname=#{@pathname.inspect} @parsed_manifest=#{truncated_parsed_manifest}>"
+    end
+
     private
 
     attr_accessor :mtime


### PR DESCRIPTION
Sometimes an exception leads to printing the inspected manifest object. This fills multiple screens with the parsed manifest hash. Most of the times though, the exception's message `Could not find "foobar.css" in manifest: <PrecompiledAssets::Manifest ....>` already helps to solve the problem.

Instead of relying on the #inpect default implementation it truncates @parsed_manifest.

Feel free to decline without comment if you don't want this change merged ;) Thx :+1: 